### PR TITLE
Allow Numba to run in Object mode

### DIFF
--- a/run.py
+++ b/run.py
@@ -77,7 +77,7 @@ class NumbaExtractor(ParakeetExtractor):
     def __init__(self):
         super(NumbaExtractor, self).__init__()
         self.extra_import = 'import numba\n'
-        self.decorator = '@numba.jit(nopython=True)\n'
+        self.decorator = '@numba.jit\n'
 
 
 class HopeExtractor(ParakeetExtractor):


### PR DESCRIPTION
Forcing Numba to only use nopython mode prevents it from compiling most of the benchmarks. If the `nopython=True`  kwarg is removed, then it can compile all of the benchmarks apart from 5 (fft, grouping, local_maxima, slowparts, and allpairs_distances - these are due to Numba not presently supporting list comprehensions, generator expressions, lambda functions, and import statements within functions). 

Removing `nopython=True` does not impact the benchmarks that can be compiled in nopython mode, because Numba always attempts to compile in nopython mode first and then falls back to object mode if necessary.