### PR TITLE
python 3 compatibility adjustments

### DIFF
--- a/benchit.py
+++ b/benchit.py
@@ -5,6 +5,7 @@ An adaptation from timeit that outputs some extra statistical informations
 from timeit import default_timer, default_repeat, Timer
 import numpy
 import sys
+import time
 
 
 def main(args=None):
@@ -20,16 +21,16 @@ def main(args=None):
     stderr and the return value is 1.  Exceptions at other times
     (including the template compilation) are not caught.
     """
-    if args is None:
+    if not args:
         args = sys.argv[1:]
     import getopt
     try:
-        opts, args = getopt.getopt(args, "n:s:r:tcvh",
-                                   ["number=", "setup=", "repeat=",
-                                    "time", "clock", "verbose", "help"])
-    except getopt.error, err:
-        print err
-        print "use -h/--help for command line help"
+        opts, args = getopt.getopt(args, 'n:s:r:tcvh',
+                                   ['number=', 'setup=', 'repeat=',
+                                    'time', 'clock', 'verbose', 'help'])
+    except getopt.error as err:
+        print(err)
+        print("use -h/--help for command line help")
         return 2
     timer = default_timer
     stmt = "\n".join(args) or "pass"
@@ -56,7 +57,7 @@ def main(args=None):
                 precision += 1
             verbose += 1
         if o in ("-h", "--help"):
-            print __doc__,
+            print(__doc__)
             return 0
     setup = "\n".join(setup) or "pass"
     # Include the current directory, so that local imports work (sys.path
@@ -75,7 +76,7 @@ def main(args=None):
                 t.print_exc()
                 return 1
             if verbose:
-                print "%d loops -> %.*g secs" % (number, precision, x)
+                print("%d loops -> %.*g secs" % (number, precision, x))
             if x >= 0.2:
                 break
     try:
@@ -84,13 +85,14 @@ def main(args=None):
         t.print_exc()
         return 1
     if verbose:
-        print "raw times:", " ".join(["%.*g" % (precision, x) for x in r])
+        print("raw times:", " ".join(["%.*g" % (precision, x) for x in r]))
     r = [int(x * 1e6 / number) for x in r]
     best = min(r)
     average = int(numpy.average(r))
     std = int(numpy.std(r))
 
-    print best, average, std
+    print(best, average, std)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/benchmarks/allpairs_distances_loops.py
+++ b/benchmarks/allpairs_distances_loops.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def allpairs_distances_loops(X,Y):
   result = np.zeros( (X.shape[0], Y.shape[0]), X.dtype)
-  for i in xrange(X.shape[0]):
-    for j in xrange(Y.shape[0]):
+  for i in range(X.shape[0]):
+    for j in range(Y.shape[0]):
       result[i,j] = np.sum( (X[i,:] - Y[j,:]) ** 2)
   return result 

--- a/benchmarks/conv.py
+++ b/benchmarks/conv.py
@@ -18,10 +18,10 @@ def conv(x, weights):
     sx = x.shape
     sw = weights.shape
     result = np.zeros_like(x)
-    for i in xrange(sx[0]):
-        for j in xrange(sx[1]):
-            for ii in xrange(sw[0]):
-                for jj in xrange(sw[1]):
-                    idx = clamp(i,ii-sw[0]/2,sw[0]), clamp(j,jj-sw[0]/2,sw[0])
+    for i in range(sx[0]):
+        for j in range(sx[1]):
+            for ii in range(sw[0]):
+                for jj in range(sw[1]):
+                    idx = clamp(i,ii-sw[0]//2,sw[0]), clamp(j,jj-sw[0]//2,sw[0])
                     result[i,j] += x[idx] * weights[ii,jj]
     return result

--- a/benchmarks/diffusion.py
+++ b/benchmarks/diffusion.py
@@ -1,4 +1,4 @@
-#setup: import numpy as np;lx,ly=(2**7,2**7);u=np.zeros([lx,ly],dtype=np.double);u[lx/2,ly/2]=1000.0;tempU=np.zeros([lx,ly],dtype=np.double)
+#setup: import numpy as np;lx,ly=(2**7,2**7);u=np.zeros([lx,ly],dtype=np.double);u[lx//2,ly//2]=1000.0;tempU=np.zeros([lx,ly],dtype=np.double)
 #run: diffusion(u,tempU,100)
 
 #pythran export diffusion(float [][], float [][], int)

--- a/benchmarks/fft.py
+++ b/benchmarks/fft.py
@@ -12,7 +12,7 @@ def fft(x):
    e=fft(x[::2])
    o=fft(x[1::2])
    M=N//2
-   l=[ e[k] + o[k]*math.e**(-2j*math.pi*k/N) for k in xrange(M) ]
-   r=[ e[k] - o[k]*math.e**(-2j*math.pi*k/N) for k in xrange(M) ]
+   l=[ e[k] + o[k]*math.e**(-2j*math.pi*k/N) for k in range(M) ]
+   r=[ e[k] - o[k]*math.e**(-2j*math.pi*k/N) for k in range(M) ]
    return np.array(l+r)
 

--- a/benchmarks/grayscott.py
+++ b/benchmarks/grayscott.py
@@ -12,8 +12,8 @@ def grayscott(counts, Du, Dv, F, k):
 
     r = 20
     u[:] = 1.0
-    U[n/2-r:n/2+r,n/2-r:n/2+r] = 0.50
-    V[n/2-r:n/2+r,n/2-r:n/2+r] = 0.25
+    U[n//2-r:n//2+r,n//2-r:n//2+r] = 0.50
+    V[n//2-r:n//2+r,n//2-r:n//2+r] = 0.25
     u += 0.15*np.random.random((n,n))
     v += 0.15*np.random.random((n,n))
 

--- a/benchmarks/growcut.py
+++ b/benchmarks/growcut.py
@@ -25,15 +25,15 @@ def growcut(image, state, state_next, window_radius):
     height = image.shape[0]
     width = image.shape[1]
 
-    for j in xrange(width):
-        for i in xrange(height):
+    for j in range(width):
+        for i in range(height):
 
             winning_colony = state[i, j, 0]
             defense_strength = state[i, j, 1]
 
-            for jj in xrange(window_floor(j, window_radius),
+            for jj in range(window_floor(j, window_radius),
                              window_ceil(j+1, width, window_radius)):
-                for ii in xrange(window_floor(i, window_radius),
+                for ii in range(window_floor(i, window_radius),
                                  window_ceil(i+1, height, window_radius)):
                     if (ii != i and jj != j):
                         d = image[i, j, 0] - image[ii, jj, 0]

--- a/benchmarks/hyantes.py
+++ b/benchmarks/hyantes.py
@@ -1,4 +1,4 @@
-#setup: import numpy ; a = numpy.array([ [i/10., i/10., i/20.] for i in xrange(80)], dtype=numpy.double)
+#setup: import numpy ; a = numpy.array([ [i/10., i/10., i/20.] for i in range(80)], dtype=numpy.double)
 #run: hyantes(0, 0, 90, 90, 1, 100, 80, 80, a)
 
 #pythran export hyantes(float, float, float, float, float, float, int, int, float[][])

--- a/benchmarks/local_maxima.py
+++ b/benchmarks/local_maxima.py
@@ -22,6 +22,6 @@ def local_maxima(data, mode=wrap):
   for pos in np.ndindex(data.shape):
     myval = data[pos]
     for offset in np.ndindex(wsize):
-      neighbor_idx = tuple(mode(p, o-w/2, w) for (p, o, w) in zip(pos, offset, wsize))
+      neighbor_idx = tuple(mode(p, o-w//2, w) for (p, o, w) in zip(pos, offset, wsize))
       result[pos] &= (data[neighbor_idx] <= myval)
   return result

--- a/benchmarks/pairwise.py
+++ b/benchmarks/pairwise.py
@@ -11,7 +11,7 @@ def pairwise(X):
     for i in range(M):
         for j in range(M):
             d = 0.0
-            for k in xrange(N):
+            for k in range(N):
                 tmp = X[i,k] - X[j,k]
                 d += tmp * tmp
             D[i,j] = np.sqrt(d)

--- a/benchmarks/smoothing.py
+++ b/benchmarks/smoothing.py
@@ -12,6 +12,6 @@ def smoothing(x, alpha):
   - Parakeet runtime: .01 seconds
   """
   s = x.copy()
-  for i in xrange(1, len(x)):
+  for i in range(1, len(x)):
     s[i] = alpha * x[i] + (1 - alpha) * s[i-1]
   return s

--- a/benchmarks/wdist.py
+++ b/benchmarks/wdist.py
@@ -11,8 +11,8 @@ def wdist(A, B, W):
     _,n = B.shape
     D = np.zeros((m, n))
 
-    for ii in xrange(m):
-        for jj in xrange(n):
+    for ii in range(m):
+        for jj in range(n):
             wdiff = (A[:,ii] - B[:,jj]) / W[:,ii]
             D[ii,jj] = np.sqrt((wdiff**2).sum())
     return D


### PR DESCRIPTION
A few python2-only-isms fixed:

- Use floor division in indexing operations to avoid floating point errors with numpy indices
- print statements need to be print functions (use parents)
- xrange no longer exists.  range in python 3 is a generator now, and supersedes xrange.  I use only range throughout now.  This may impact python 2 usage of this test suite for the worse.

The last point may be contentious.  If you'd like, I can rework things to use some kind of fallback  and use xrange when it exists.