### PR TITLE
Activate simd

### DIFF
--- a/numpy_benchmarks/np-bench
+++ b/numpy_benchmarks/np-bench
@@ -155,7 +155,8 @@ class XtensorExtractor(PythonExtractor):
                                   libraries=["openblas"],
                                   include_dirs=[os.path.join(sys.prefix,
                                                              'include')],
-                                  extra_compile_args=['-std=c++14', '-w']
+                                  extra_compile_args=['-std=c++14', '-w', '-march=native'],
+                                  define_macros=[('XTENSOR_USE_XSIMD', None)]
                                  )
             script_args = [] if verbose else ['--quiet']
             script_args.extend(['build_ext', '--inplace'])


### PR DESCRIPTION
Description
---

- activate simd in `xtensor` adding macro definition `XTENSOR_USE_XSIMD` in tests
- bump versions of `xtensor` and `xtensor-python` to be able to use simd with `pyarray`/`pytensor`
- add `-march=native` flag to use the full capabilities of the hardware